### PR TITLE
Upgrade Build.Utilities to v4

### DIFF
--- a/Kobush.Build.csproj
+++ b/Kobush.Build.csproj
@@ -54,7 +54,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
I'm not sure if you'd consider taking a dependency on Build.Utilities.v4.0 but I was unable to use the library on Ubuntu 15.10 after upgrading to the latest mono as the compiler complained that the v2 version could not be found. This fix worked in my environment to get around the compile issue and I figured I'd offer it in case you were interested.
